### PR TITLE
Simulation of Quantum Devices exam

### DIFF
--- a/year_4/TUM_quantum_sim/Dual_QW/main.py
+++ b/year_4/TUM_quantum_sim/Dual_QW/main.py
@@ -1,4 +1,4 @@
-from TUM_quantum_sim.Dual_QW import DQW_LOGGER
+from TUM_quantum_sim.Dual_QW import DQW_LOGGER as  logging
 
 from TUM_quantum_sim import constants as c
 
@@ -44,7 +44,7 @@ def calc_dn_dmu(E: np.ndarray, m: float, mu: float, T: float) -> float:
     return DOS_2D(m) * c.kb * T * sum(d_fermi_dirac(Ei, mu, T) for Ei in E)
 
 def main():
-    DQW_LOGGER.info("Starting simulation")
+    logging.info("Starting simulation")
 
     matplotlib.use("QtAgg")
     
@@ -60,14 +60,14 @@ def main():
     z = np.linspace(-L/2, L/2, N)
     dz = z[1] - z[0]
 
-    DQW_LOGGER.info("Calculating potential")
+    logging.info("Calculating potential")
     V = potential(z, a, Vb, E)
 
     # plt.figure()
     # plt.plot(z, V)
     # plt.show()
 
-    DQW_LOGGER.info("Finding stationary eigenstates")
+    logging.info("Finding stationary eigenstates")
     # hamiltonian
     h0 = -c.hbar**2 / (2 * m * dz**2)
     H0 = h0 * sp.diags([1, -2, 1], [-1, 0, 1], shape=(N, N), dtype=np.complex128, format="csc")
@@ -81,9 +81,9 @@ def main():
     # find the five smallest (algebraic, not in absolute value) eigenvalues
     En, psi = sp.linalg.eigsh(H0, k=5, which="SA")
 
-    DQW_LOGGER.info("Found 5 stationary eigenstates")
+    logging.info("Found 5 stationary eigenstates")
     for i in range(len(En)):
-        DQW_LOGGER.info(f"E{i} = {En[i] / c.e0 :.3f} eV")
+        logging.info(f"E{i} = {En[i] / c.e0 :.3f} eV")
 
     # plt.figure()
     # plt.suptitle("$|\Psi_{1,2}|^2$")
@@ -97,7 +97,7 @@ def main():
     # plt.show()
     
     # estimate mu with newton's method
-    DQW_LOGGER.info("Estimating mu")
+    logging.info("Estimating mu")
     mu_n = -2.5*c.e0
     tol = c.e0 * 1e-10
     error = float("inf")
@@ -107,10 +107,10 @@ def main():
         mu_n -= error
 
 
-    DQW_LOGGER.info(f"mu = {mu_n / c.e0 :.3f} eV")
-    DQW_LOGGER.info(f"n = {calc_n(En, m, mu_n, T) :.3e}")
+    logging.info(f"mu = {mu_n / c.e0 :.3f} eV")
+    logging.info(f"n = {calc_n(En, m, mu_n, T) :.3e}")
 
-    DQW_LOGGER.info("Simulation finished, exiting...")
+    logging.info("Simulation finished, exiting...")
 
 if __name__ == "__main__":
     main()

--- a/year_4/TUM_quantum_sim/RTD_sim/system.py
+++ b/year_4/TUM_quantum_sim/RTD_sim/system.py
@@ -134,12 +134,12 @@ class System:
         Returns:
             float | np.ndarray: potential 
         """
-        if isinstance(z, float):
+        if isinstance(z, float) or isinstance(z, int):
             return self._V(z)
         elif isinstance(z, np.ndarray):
             return np.vectorize(self._V)(z)
         else:
-            raise TypeError("Invalid type for argument 'z'")
+            raise TypeError(f"Invalid type for argument 'z': {type(z)}")
 
     @lru_cache
     def m_star(self, z: float) -> float:

--- a/year_4/TUM_quantum_sim/SQUID/main.py
+++ b/year_4/TUM_quantum_sim/SQUID/main.py
@@ -1,4 +1,4 @@
-from TUM_quantum_sim.SQUID import SQUID_LOGGER
+from TUM_quantum_sim.SQUID import SQUID_LOGGER as logging
 
 from TUM_quantum_sim import constants as c
 
@@ -70,7 +70,7 @@ def potential(
     return static_potential(z, a, Vb) + temporal_potential(z, t, E, omega)
 
 def main():
-    SQUID_LOGGER.info("Starting simulation")
+    logging.info("Starting simulation")
 
     matplotlib.use("QtAgg")
     
@@ -83,14 +83,14 @@ def main():
     z = np.linspace(-L/2, L/2, N)
     dz = z[1] - z[0]
 
-    SQUID_LOGGER.info("Calculating potential")
+    logging.info("Calculating potential")
     V0 = static_potential(z, a, Vb)
 
     # plt.figure()
     # plt.plot(z, V)
     # plt.show()
 
-    SQUID_LOGGER.info("Finding stationary eigenstates")
+    logging.info("Finding stationary eigenstates")
     # hamiltonian
     h0 = -c.hbar**2 / (2 * m * dz**2)
     H0 = h0 * sp.diags([1, -2, 1], [-1, 0, 1], shape=(N, N), dtype=np.complex128, format="csc")
@@ -134,9 +134,9 @@ def main():
     # E = omega = 0
 
 
-    SQUID_LOGGER.info(f"{dt = :.2e}")
-    SQUID_LOGGER.info(f"{E = :.2e}")
-    SQUID_LOGGER.info(f"{omega = :.2e}")
+    logging.info(f"{dt = :.2e}")
+    logging.info(f"{E = :.2e}")
+    logging.info(f"{omega = :.2e}")
 
     psi_n = (psi1 + psi2) * 2**-0.5
     psi = [psi_n]
@@ -161,7 +161,7 @@ def main():
             psi.append(psi_n)
             t.append(tn)
             V.append(V0 + Vt)
-            SQUID_LOGGER.info(f"{tn = :.2e}")
+            logging.info(f"{tn = :.2e}")
 
     t = np.array(t)
     psi = np.array(psi)
@@ -199,7 +199,7 @@ def main():
     ani = FuncAnimation(fig, update, frames=frames, init_func=init, blit=True)
     plt.show()
 
-    SQUID_LOGGER.info("Simulation finished, exiting...")
+    logging.info("Simulation finished, exiting...")
 
 if __name__ == "__main__":
     main()

--- a/year_4/TUM_quantum_sim/SQUID/main.py
+++ b/year_4/TUM_quantum_sim/SQUID/main.py
@@ -151,7 +151,7 @@ def main():
         Vt = temporal_potential(z, tn + dt, E, omega)
         Hn = prefactor * (H0 + sp.diags(Vt))
 
-        psi_n = sp.linalg.inv(I - Hn) @ (I + H) @ psi_n
+        psi_n = sp.linalg.spsolve(I - Hn, (I + H) @ psi_n)
 
         tn += dt
         H = Hn

--- a/year_4/TUM_quantum_sim/__main__.py
+++ b/year_4/TUM_quantum_sim/__main__.py
@@ -3,11 +3,13 @@ from TUM_quantum_sim.RTD_sim import main as RTD
 from TUM_quantum_sim.SQUID import main as SQUID
 from TUM_quantum_sim.Dual_QW import main as Dual_QW
 from TUM_quantum_sim.QCL import main as QCL
+from TUM_quantum_sim.exam import main as exam
 
 if __name__ == "__main__":
     # RTD.main()
     # QW.main()
     # SQUID.main()
     # Dual_QW.main()
-    QCL.main()
+    # QCL.main()
+    exam.main()
     pass

--- a/year_4/TUM_quantum_sim/exam/__init__.py
+++ b/year_4/TUM_quantum_sim/exam/__init__.py
@@ -1,0 +1,15 @@
+"""
+Superconducting quantum interference device simulation software.
+
+Simulated using finite difference and leapfrog time propagation
+"""
+
+import logging
+
+EXAM_LOGGER = logging.getLogger("EXAM")
+
+logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.INFO,
+        datefmt='%H:%M:%S'
+    )

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -76,6 +76,7 @@ def main():
     prefactor = dt/(2j * c.hbar)
     H = prefactor * H0
 
+    logging.info(f"Starting temporal simulation for {t_end / 1e-15 :.1f} ps")
     while tn < t_end:
         Vt = potential.temporal(z, tn + dt, E, omega)
         Hn = prefactor * (H0 + sp.diags(Vt))
@@ -90,22 +91,15 @@ def main():
             psi.append(psi_n)
             t.append(tn)
             V.append(V0 + Vt)
-            logging.info(f"{tn = :.2e}")
 
     t = np.array(t)
     psi = np.array(psi)
     V = np.array(V)
+    
+    logging.info("Temporal simulation completed")
 
+    plot.psi_3D(z, t, psi)
     return
-    # 3D plot
-    # fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
-    # X, Y = np.meshgrid(z, t)
-    # surf = ax.plot_surface(X, Y, abs(psi)**2, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
-    # plt.xlabel("z [m]")
-    # plt.ylabel("t [s]")
-    # plt.title("$|\Psi|^2$")
-    # fig.colorbar(surf, shrink=0.5, aspect=5)
-    # plt.show()
 
     # animation
     fig, (ax1, ax2) = plt.subplots(2, 1)

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -57,15 +57,19 @@ def main():
     logging.info(f"{omega = :.2e}")
 
     tn = 0
-    t = [tn]
     t_end = 50e-15
-    t_store = 0.5e-15 # time between each stored psi
-
-    psi_0 = (psi1 + psi2) * 2**-0.5
-    psi_1 = psi_0
-    psi = [psi_0]
+    t_store = 0.5e-15 # time between each data storage
+    t = [tn]
 
     V = [V0]
+
+    # calculate initial psi
+    psi_half = (psi1 + psi2) * 2**-0.5
+    V_half = potential.temporal(z, dt/2, E, omega)
+    H_half = dt/(2j * c.hbar) * (H0 + sp.diags(V_half)) @ psi_half
+    psi_0 = psi_half - H_half
+    psi_1 = psi_half + H_half
+    psi = [psi_0]
 
     logging.info(f"Starting temporal simulation for {t_end / 1e-15 :.1f} ps")
     while tn < t_end:
@@ -86,7 +90,9 @@ def main():
 
         # store data every {t_store} seconds
         if tn // t_store > len(psi):
-            psi.append(psi_2)
+            # approximation
+            abs_psi_squared = 0.5 * (np.conjugate(psi_1) * psi_2 + psi_1 * np.conjugate(psi_2))
+            psi.append(abs_psi_squared)
             t.append(tn)
             V.append(V0 + Vt)
 
@@ -96,9 +102,9 @@ def main():
     
     logging.info("Temporal simulation completed")
 
-    # plot.psi_3D(z, t, psi)
+    # plot.psi2_3D(z, t, psi)
 
-    plot.psi_animation(z, V, psi)
+    plot.psi2_animation(z, V, psi)
     
 
     logging.info("Simulation finished, exiting...")

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -49,6 +49,9 @@ def main():
 
     # find the smallest (algebraic, not in absolute value) eigenvalues
     _E, _psi = sp.linalg.eigsh(H0, k=n_states, which="SA")
+    # normalise
+    for i in range(n_states):
+        _psi[:, i] /= np.sqrt(np.trapz(_psi[:, i]**2, z))
 
     logging.info("Eigenstates found.")
     # plot.psi(z, _E, _psi)

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -38,13 +38,13 @@ def main():
 
     # hamiltonian
     h0 = -c.hbar**2 / (2 * m * dz**2)
-    H0 = Hamiltonian(h0 * sp.diags(
-        [1, -2, 1], [-1, 0, 1], 
+    H0 = Hamiltonian(sp.diags(
+        [h0, -2*h0, h0], [-1, 0, 1], 
         shape=(N, N), 
         dtype=np.complex128, 
         format="dia"
         ))
-    H0 = H0 + V0
+    H0.add_static_potential(V0)
     # plot.H(H0)
 
     # find the smallest (algebraic, not in absolute value) eigenvalues
@@ -66,7 +66,7 @@ def main():
     # calculate initial psi
     psi_half = (_psi[:, 0] + _psi[:, 1]) * 2**-0.5
     V_half = potential.temporal(z, dt/2, E, omega)
-    H_half = (H0 + V_half) @ (dt/(2j * c.hbar) * psi_half)
+    H_half = H0.add(V_half) @ (dt/(2j * c.hbar) * psi_half)
     psi_0 = psi_half - H_half
     psi_1 = psi_half + H_half
     psi = [np.abs(psi_0)**2]
@@ -76,6 +76,7 @@ def main():
     V = [V0]    # array for storing potentials
 
     logging.info(f"Starting temporal simulation for {t_end / 1e-15 :.1f} fs")
+    coef = 2*dt/(1j * c.hbar)
     while tn < t_end:
         
         # Leapfrog
@@ -85,7 +86,7 @@ def main():
 
         Vt = potential.temporal(z, tn, E, omega)
 
-        psi_2 = (H0 + Vt) @ (2*dt/(1j * c.hbar) * psi_1) + psi_0
+        psi_2 = H0.add(Vt) @ (coef * psi_1) + psi_0
 
         psi_0, psi_1 = psi_1, psi_2
 

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -80,7 +80,7 @@ def main():
         Vt = potential.temporal(z, tn + dt, E, omega)
         Hn = prefactor * (H0 + sp.diags(Vt))
 
-        psi_n = sp.linalg.inv(I - Hn) @ (I + H) @ psi_n
+        psi_n = sp.linalg.spsolve(I - Hn, (I + H) @ psi_n)
 
         tn += dt
         H = Hn

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -66,7 +66,7 @@ def main():
     # calculate initial psi
     psi_half = (_psi[:, 0] + _psi[:, 1]) * 2**-0.5
     V_half = potential.temporal(z, dt/2, E, omega)
-    H_half = dt/(2j * c.hbar) * (H0 + V_half) @ psi_half
+    H_half = (H0 + V_half) @ (dt/(2j * c.hbar) * psi_half)
     psi_0 = psi_half - H_half
     psi_1 = psi_half + H_half
     psi = [np.abs(psi_0)**2]
@@ -84,9 +84,8 @@ def main():
         # H^n = H0 + V^n
 
         Vt = potential.temporal(z, tn, E, omega)
-        H = 2*dt/(1j * c.hbar) * (H0 + Vt)
 
-        psi_2 = H @ psi_1 + psi_0
+        psi_2 = (H0 + Vt) @ (2*dt/(1j * c.hbar) * psi_1) + psi_0
 
         psi_0, psi_1 = psi_1, psi_2
 
@@ -108,7 +107,7 @@ def main():
 
     # plot.psi2_3D(z, t, psi)
 
-    plot.psi2_animation(z, V, psi)
+    # plot.psi2_animation(z, V, psi)
     
     # plot.psi2_z(t, np.nonzero(z == 0.0)[0], psi)
 

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -2,11 +2,8 @@ from TUM_quantum_sim.exam import EXAM_LOGGER as logging
 
 from TUM_quantum_sim import constants as c
 from TUM_quantum_sim.exam import potential
+from TUM_quantum_sim.exam import plot
 
-from matplotlib import pyplot as plt
-import matplotlib
-from matplotlib import cm
-from matplotlib.animation import FuncAnimation
 import numpy as np
 from scipy import sparse as sp
 
@@ -14,13 +11,12 @@ from scipy import sparse as sp
 def main():
     logging.info("Starting simulation")
 
-    matplotlib.use("QtAgg")
-    
     a = 1e-9
     L = 2*a
     N = 50
     m = c.me
     Vb = c.e0
+    n_states = 2
 
     z = np.linspace(-L/2, L/2, N)
     dz = z[1] - z[0]
@@ -28,37 +24,28 @@ def main():
     logging.info("Calculating potential")
     V0 = potential.static(z, a, Vb)
 
-    # plt.figure()
-    # plt.plot(z, V)
-    # plt.show()
+    # plot.V(z, V0)
 
-    logging.info("Finding stationary eigenstates")
+    logging.info(f"Finding {n_states} stationary eigenstates")
+
     # hamiltonian
     h0 = -c.hbar**2 / (2 * m * dz**2)
-    H0 = h0 * sp.diags([1, -2, 1], [-1, 0, 1], shape=(N, N), dtype=np.complex128, format="csc")
+    H0 = h0 * sp.diags(
+        [1, -2, 1], [-1, 0, 1], 
+        shape=(N, N), 
+        dtype=np.complex128, 
+        format="csc"
+        )
     H0 += sp.diags(V0)
 
-    # plt.figure()
-    # plt.title("Hamiltonian")
-    # plt.imshow(H0.toarray())
-    # plt.show()
+    # plot.H(H0)
 
-    # find the two smallest (algebraic, not in absolute value) eigenvalues
-    _E, _psi = sp.linalg.eigsh(H0, k=2, which="SA")
+    # find the smallest (algebraic, not in absolute value) eigenvalues
+    _E, _psi = sp.linalg.eigsh(H0, k=n_states, which="SA")
     psi1 = _psi[:, 0]
     psi2 = _psi[:, 1]
 
-    # plt.figure()
-    # plt.suptitle("$|\Psi_{1,2}|^2$")
-    # plt.subplot(2, 1, 1)
-    # plt.plot(z, abs(psi1)**2)
-    # plt.title(_E[0] / c.e0)
-    # plt.subplot(2, 1, 2)
-    # plt.plot(z, abs(psi2)**2)
-    # plt.title(_E[1] / c.e0)
-    # plt.tight_layout()
-    # plt.show()
-
+    # plot.psi(z, _E, _psi)
 
     # Crank-Nicholson
     # psi^n+1 = psi^n + dt/2 * (F^n + F^n+1)
@@ -109,6 +96,7 @@ def main():
     psi = np.array(psi)
     V = np.array(V)
 
+    return
     # 3D plot
     # fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
     # X, Y = np.meshgrid(z, t)

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -32,7 +32,7 @@ def main():
     logging.info("Calculating potential")
     V0 = potential.static(z, a, Vb)
 
-    # plot.V(z, V0)
+    plot.V(z, V0)
 
     logging.info(f"Finding {n_states} stationary eigenstates")
 
@@ -45,7 +45,8 @@ def main():
         format="dia"
         ))
     H0.add_static_potential(V0)
-    # plot.H(H0)
+
+    plot.H(H0)
 
     # find the smallest (algebraic, not in absolute value) eigenvalues
     _E, _psi = sp.linalg.eigsh(H0, k=n_states, which="SA")
@@ -54,11 +55,11 @@ def main():
         _psi[:, i] /= np.sqrt(np.trapz(_psi[:, i]**2, z))
 
     logging.info("Eigenstates found.")
-    # plot.psi(z, _E, _psi)
+    plot.psi(z, _E, _psi)
 
     logging.info("Performing setup for temporal simulation")
     # estimate a decent dt from lectures
-    V_max = V0 + potential.temporal(z, np.pi, E, 1)
+    V_max = V0 + potential.temporal(z, np.pi/2, E, 1)
     E_max = max(
         abs(min(V_max)),
         abs(max(V_max) + 4 * abs(h0)),
@@ -109,9 +110,9 @@ def main():
     
     logging.info("Temporal simulation completed")
 
-    # plot.psi2_3D(z, t, psi)
+    plot.psi2_3D(z, t, psi)
 
-    # plot.psi2_animation(z, V, psi)
+    plot.psi2_animation(z, V, psi)
     
     # plot.psi2_z(t, np.nonzero(z == 0.0)[0], psi)
 

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -1,6 +1,7 @@
-from TUM_quantum_sim.SQUID import SQUID_LOGGER as logging
+from TUM_quantum_sim.exam import EXAM_LOGGER as logging
 
 from TUM_quantum_sim import constants as c
+from TUM_quantum_sim.exam import potential
 
 from matplotlib import pyplot as plt
 import matplotlib
@@ -9,65 +10,6 @@ from matplotlib.animation import FuncAnimation
 import numpy as np
 from scipy import sparse as sp
 
-def static_potential(
-    z: float | np.ndarray,
-    a: float,
-    Vb: float
-    ) -> np.ndarray:
-    """create a discretised array of the potential
-
-    Args:
-        z (float | np.ndarray): z coordinate in potential, [m]
-        a (float): Potential function parameter, [m]
-        Vb (float): Energy scaling, [J]
-
-    Returns:
-        float | np.ndarray: potential [J]
-    """
-    z0 = a / (4*2**0.5)
-    return Vb * (-0.25 * (z/z0)**2 + 1/64 * (z/z0)**4)
-
-def temporal_potential(
-    z: float | np.ndarray,
-    t: float,
-    E: float,
-    omega: float
-    ) -> float | np.ndarray:
-    """Calculate the temporal evolution of the potential
-
-    Args:
-        z (float | np.ndarray): position [m]
-        t (float): time [s]
-        E (float): Electric field strength [V/m]
-        omega (float): frequency, [rad/s]
-
-    Returns:
-        float | np.ndarray: potential [J]
-    """
-    return -c.e0 * E * z * np.sin(omega * t)
-
-def potential(
-    z: float | np.ndarray,
-    t: float,
-    a: float,
-    Vb: float,
-    E: float,
-    omega: float
-    ) -> float | np.ndarray:
-    """Calculate potential
-
-    Args:
-        z (float | np.ndarray): z coordinate in potential, [m]
-        t (float): time [s]
-        a (float): Potential function parameter, [m]
-        Vb (float): Energy scaling, [J]
-        E (float): Electric field strength [V/m]
-        omega (float): frequency, [rad/s]
-
-    Returns:
-        float | np.ndarray: potential [J]
-    """
-    return static_potential(z, a, Vb) + temporal_potential(z, t, E, omega)
 
 def main():
     logging.info("Starting simulation")
@@ -84,7 +26,7 @@ def main():
     dz = z[1] - z[0]
 
     logging.info("Calculating potential")
-    V0 = static_potential(z, a, Vb)
+    V0 = potential.static(z, a, Vb)
 
     # plt.figure()
     # plt.plot(z, V)
@@ -148,7 +90,7 @@ def main():
     H = prefactor * H0
 
     while tn < t_end:
-        Vt = temporal_potential(z, tn + dt, E, omega)
+        Vt = potential.temporal(z, tn + dt, E, omega)
         Hn = prefactor * (H0 + sp.diags(Vt))
 
         psi_n = sp.linalg.inv(I - Hn) @ (I + H) @ psi_n

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -22,9 +22,9 @@ def main():
     E = 1e9
     omega = np.pi*200e12
     t_end = 100e-15     # end of simulation
-    t_store = 2e-15     # time between each data storage
+    t_store = 1e-15     # time between each data storage
 
-    E = omega = 0       # override 
+    # E = omega = 0       # override 
 
     z = np.linspace(-L/2, L/2, N)
     dz = z[1] - z[0]
@@ -36,7 +36,7 @@ def main():
 
     logging.info(f"Finding {n_states} stationary eigenstates")
 
-    # hamiltonian
+    # Set up hamiltonian
     h0 = -c.hbar**2 / (2 * m * dz**2)
     H0 = Hamiltonian(sp.diags(
         [h0, -2*h0, h0], [-1, 0, 1], 
@@ -81,8 +81,10 @@ def main():
 
     logging.info(f"Starting temporal simulation for {t_end / 1e-15 :.1f} fs")
     coef = 2*dt/(1j * c.hbar)
+    steps = 0
     while tn < t_end:
-        
+        steps += 1
+
         # Leapfrog
         # psi^n+1 = psi^n-1 + 2*dt*F^n
         # F^n = 1/ihbar * H^n @ psi^n
@@ -109,6 +111,7 @@ def main():
     V = np.array(V)
     
     logging.info("Temporal simulation completed")
+    logging.info(f"Took {steps} steps, stored data {len(t)} times")
 
     plot.psi2_3D(z, t, psi)
 

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -1,0 +1,205 @@
+from TUM_quantum_sim.SQUID import SQUID_LOGGER as logging
+
+from TUM_quantum_sim import constants as c
+
+from matplotlib import pyplot as plt
+import matplotlib
+from matplotlib import cm
+from matplotlib.animation import FuncAnimation
+import numpy as np
+from scipy import sparse as sp
+
+def static_potential(
+    z: float | np.ndarray,
+    a: float,
+    Vb: float
+    ) -> np.ndarray:
+    """create a discretised array of the potential
+
+    Args:
+        z (float | np.ndarray): z coordinate in potential, [m]
+        a (float): Potential function parameter, [m]
+        Vb (float): Energy scaling, [J]
+
+    Returns:
+        float | np.ndarray: potential [J]
+    """
+    z0 = a / (4*2**0.5)
+    return Vb * (-0.25 * (z/z0)**2 + 1/64 * (z/z0)**4)
+
+def temporal_potential(
+    z: float | np.ndarray,
+    t: float,
+    E: float,
+    omega: float
+    ) -> float | np.ndarray:
+    """Calculate the temporal evolution of the potential
+
+    Args:
+        z (float | np.ndarray): position [m]
+        t (float): time [s]
+        E (float): Electric field strength [V/m]
+        omega (float): frequency, [rad/s]
+
+    Returns:
+        float | np.ndarray: potential [J]
+    """
+    return -c.e0 * E * z * np.sin(omega * t)
+
+def potential(
+    z: float | np.ndarray,
+    t: float,
+    a: float,
+    Vb: float,
+    E: float,
+    omega: float
+    ) -> float | np.ndarray:
+    """Calculate potential
+
+    Args:
+        z (float | np.ndarray): z coordinate in potential, [m]
+        t (float): time [s]
+        a (float): Potential function parameter, [m]
+        Vb (float): Energy scaling, [J]
+        E (float): Electric field strength [V/m]
+        omega (float): frequency, [rad/s]
+
+    Returns:
+        float | np.ndarray: potential [J]
+    """
+    return static_potential(z, a, Vb) + temporal_potential(z, t, E, omega)
+
+def main():
+    logging.info("Starting simulation")
+
+    matplotlib.use("QtAgg")
+    
+    a = 1e-9
+    L = 2*a
+    N = 50
+    m = c.me
+    Vb = c.e0
+
+    z = np.linspace(-L/2, L/2, N)
+    dz = z[1] - z[0]
+
+    logging.info("Calculating potential")
+    V0 = static_potential(z, a, Vb)
+
+    # plt.figure()
+    # plt.plot(z, V)
+    # plt.show()
+
+    logging.info("Finding stationary eigenstates")
+    # hamiltonian
+    h0 = -c.hbar**2 / (2 * m * dz**2)
+    H0 = h0 * sp.diags([1, -2, 1], [-1, 0, 1], shape=(N, N), dtype=np.complex128, format="csc")
+    H0 += sp.diags(V0)
+
+    # plt.figure()
+    # plt.title("Hamiltonian")
+    # plt.imshow(H0.toarray())
+    # plt.show()
+
+    # find the two smallest (algebraic, not in absolute value) eigenvalues
+    _E, _psi = sp.linalg.eigsh(H0, k=2, which="SA")
+    psi1 = _psi[:, 0]
+    psi2 = _psi[:, 1]
+
+    # plt.figure()
+    # plt.suptitle("$|\Psi_{1,2}|^2$")
+    # plt.subplot(2, 1, 1)
+    # plt.plot(z, abs(psi1)**2)
+    # plt.title(_E[0] / c.e0)
+    # plt.subplot(2, 1, 2)
+    # plt.plot(z, abs(psi2)**2)
+    # plt.title(_E[1] / c.e0)
+    # plt.tight_layout()
+    # plt.show()
+
+
+    # Crank-Nicholson
+    # psi^n+1 = psi^n + dt/2 * (F^n + F^n+1)
+    # F^n = 1/ihbar * H^n @ psi^n
+    # H^n = H0 + V^n
+    # Rearrange this by hand to get the stuff in the while loop
+    tn = 0
+    t = [tn]
+    t_end = 10e-15
+    t_store = 0.25e-15 # time between each stored psi
+    dt = 0.25 * (np.max(V0) + 4 * abs(h0))
+
+    E = 1e9
+    omega = np.pi*200e12
+    # E = omega = 0
+
+
+    logging.info(f"{dt = :.2e}")
+    logging.info(f"{E = :.2e}")
+    logging.info(f"{omega = :.2e}")
+
+    psi_n = (psi1 + psi2) * 2**-0.5
+    psi = [psi_n]
+
+    V = [V0]
+
+    I = sp.eye(N, N, format="csc")
+    prefactor = dt/(2j * c.hbar)
+    H = prefactor * H0
+
+    while tn < t_end:
+        Vt = temporal_potential(z, tn + dt, E, omega)
+        Hn = prefactor * (H0 + sp.diags(Vt))
+
+        psi_n = sp.linalg.inv(I - Hn) @ (I + H) @ psi_n
+
+        tn += dt
+        H = Hn
+
+        # store every 1fs
+        if tn // t_store > len(psi):
+            psi.append(psi_n)
+            t.append(tn)
+            V.append(V0 + Vt)
+            logging.info(f"{tn = :.2e}")
+
+    t = np.array(t)
+    psi = np.array(psi)
+    V = np.array(V)
+
+    # 3D plot
+    # fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+    # X, Y = np.meshgrid(z, t)
+    # surf = ax.plot_surface(X, Y, abs(psi)**2, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
+    # plt.xlabel("z [m]")
+    # plt.ylabel("t [s]")
+    # plt.title("$|\Psi|^2$")
+    # fig.colorbar(surf, shrink=0.5, aspect=5)
+    # plt.show()
+
+    # animation
+    fig, (ax1, ax2) = plt.subplots(2, 1)
+    ln_psi, = ax1.plot(z, abs(psi[0, :])**2)
+    ln_V, = ax2.plot(z, V[0, :])
+
+    def init():
+        ax1.set_ylim(0, 0.2)
+        ax2.set_ylim(-2*c.e0, 10*c.e0)
+        return ln_psi, ln_V,
+
+    def frames():
+        for n in range(psi.shape[0]):
+            yield psi[n, :], V[n, :]
+
+    def update(data):
+        ln_psi.set_data(z, abs(data[0])**2)
+        ln_V.set_data(z, data[1])
+        return ln_psi, ln_V,
+
+    ani = FuncAnimation(fig, update, frames=frames, init_func=init, blit=True)
+    plt.show()
+
+    logging.info("Simulation finished, exiting...")
+
+if __name__ == "__main__":
+    main()

--- a/year_4/TUM_quantum_sim/exam/main.py
+++ b/year_4/TUM_quantum_sim/exam/main.py
@@ -3,6 +3,7 @@ from TUM_quantum_sim.exam import EXAM_LOGGER as logging
 from TUM_quantum_sim import constants as c
 from TUM_quantum_sim.exam import potential
 from TUM_quantum_sim.exam import plot
+from TUM_quantum_sim.exam.sparse_override import Hamiltonian
 
 import numpy as np
 from scipy import sparse as sp
@@ -14,13 +15,13 @@ def main():
     # simulation setup
     a = 1e-9
     L = 2*a
-    N = 51              
+    N = 50
     m = c.me
     Vb = c.e0
     n_states = 2
     E = 1e9
     omega = np.pi*200e12
-    t_end = 1000e-15    # end of simulation
+    t_end = 100e-15     # end of simulation
     t_store = 2e-15     # time between each data storage
 
     E = omega = 0       # override 
@@ -37,14 +38,13 @@ def main():
 
     # hamiltonian
     h0 = -c.hbar**2 / (2 * m * dz**2)
-    H0 = h0 * sp.diags(
+    H0 = Hamiltonian(h0 * sp.diags(
         [1, -2, 1], [-1, 0, 1], 
         shape=(N, N), 
         dtype=np.complex128, 
-        format="csc"
-        )
-    H0 += sp.diags(V0)
-
+        format="dia"
+        ))
+    H0 = H0 + V0
     # plot.H(H0)
 
     # find the smallest (algebraic, not in absolute value) eigenvalues
@@ -55,13 +55,18 @@ def main():
 
     logging.info("Performing setup for temporal simulation")
     # estimate a decent dt from lectures
-    dt = 0.25 * (np.max(V0) + 4 * abs(h0))
+    V_max = V0 + potential.temporal(z, np.pi, E, 1)
+    E_max = max(
+        abs(min(V_max)),
+        abs(max(V_max) + 4 * abs(h0)),
+        )
+    dt = 0.5 * c.hbar / E_max
     logging.info(f"{dt = :.2e} s")
 
     # calculate initial psi
     psi_half = (_psi[:, 0] + _psi[:, 1]) * 2**-0.5
     V_half = potential.temporal(z, dt/2, E, omega)
-    H_half = dt/(2j * c.hbar) * (H0 + sp.diags(V_half)) @ psi_half
+    H_half = dt/(2j * c.hbar) * (H0 + V_half) @ psi_half
     psi_0 = psi_half - H_half
     psi_1 = psi_half + H_half
     psi = [np.abs(psi_0)**2]
@@ -79,7 +84,7 @@ def main():
         # H^n = H0 + V^n
 
         Vt = potential.temporal(z, tn, E, omega)
-        H = 2*dt/(1j * c.hbar) * (H0 + sp.diags(Vt))
+        H = 2*dt/(1j * c.hbar) * (H0 + Vt)
 
         psi_2 = H @ psi_1 + psi_0
 
@@ -103,7 +108,7 @@ def main():
 
     # plot.psi2_3D(z, t, psi)
 
-    # plot.psi2_animation(z, V, psi)
+    plot.psi2_animation(z, V, psi)
     
     # plot.psi2_z(t, np.nonzero(z == 0.0)[0], psi)
 

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -38,3 +38,14 @@ def psi(z: np.ndarray, E: np.ndarray, psi: np.ndarray):
     plt.title(E[1] / c.e0)
     plt.tight_layout()
     plt.show()
+
+def psi_3D(z: np.ndarray, t: np.ndarray, psi: np.ndarray):
+    fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+    X, Y = np.meshgrid(z, t)
+    surf = ax.plot_surface(X, Y, abs(psi)**2, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
+    plt.xlabel("z [m]")
+    plt.ylabel("t [s]")
+    plt.title("$|\Psi|^2$")
+    fig.colorbar(surf, shrink=0.5, aspect=5)
+    plt.show()
+

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -29,13 +29,14 @@ def H(H: sp.spmatrix):
 
 def psi(z: np.ndarray, E: np.ndarray, psi: np.ndarray):
     plt.figure()
-    plt.suptitle("$|\Psi_{1,2}|^2$")
-    plt.subplot(2, 1, 1)
-    plt.plot(z, abs(psi[:, 0])**2)
-    plt.title(f"E$_1$: {E[0] / c.e0 :.3f} eV")
-    plt.subplot(2, 1, 2)
-    plt.plot(z, abs(psi[:, 1])**2)
-    plt.title(f"E$_2$: {E[1] / c.e0 :.3f} eV")
+    plt.title("$|\Psi_{1,2}|^2$")
+    plt.plot(z / 1e-9, abs(psi[:, 0])**2)
+    plt.plot(z / 1e-9, abs(psi[:, 1])**2)
+    plt.xlabel("z [nm]")
+    plt.legend([
+        f"E$_1$: {E[0] / c.e0 :.3f} eV",
+        f"E$_2$: {E[1] / c.e0 :.3f} eV"
+        ])
     plt.tight_layout()
     plt.show()
 

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -49,3 +49,28 @@ def psi_3D(z: np.ndarray, t: np.ndarray, psi: np.ndarray):
     fig.colorbar(surf, shrink=0.5, aspect=5)
     plt.show()
 
+def psi_animation(z: np.ndarray, V: np.ndarray, psi: np.ndarray):
+    fig, (ax1, ax2) = plt.subplots(2, 1)
+
+    ln_psi, = ax1.plot(z, abs(psi[0, :])**2)
+    ln_V, = ax2.plot(z, V[0, :])
+
+    def init():
+        ax1.set_title("$|\Psi|^2$")
+        ax2.set_title("Potential [eV]")
+        ax1.set_ylim(0, 0.2)
+        ax2.set_ylim(-2, 10)
+        fig.tight_layout()
+        return ln_psi, ln_V,
+
+    def frames():
+        for n in range(psi.shape[0]):
+            yield psi[n, :], V[n, :]
+
+    def update(data):
+        ln_psi.set_data(z, abs(data[0])**2)
+        ln_V.set_data(z, data[1] / c.e0)
+        return ln_psi, ln_V,
+
+    ani = FuncAnimation(fig, update, frames=frames, init_func=init, blit=True)
+    plt.show()

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -1,0 +1,40 @@
+
+from matplotlib import pyplot as plt
+import matplotlib
+from matplotlib import cm
+from matplotlib.animation import FuncAnimation
+
+import numpy as np
+from scipy import sparse as sp
+
+from TUM_quantum_sim import constants as c
+
+## BAD PRACTICE TO RUN CODE ON IMPORT
+matplotlib.use("QtAgg")
+
+
+def V(z: np.ndarray, V: np.ndarray):
+    plt.figure()
+    plt.plot(z * 1e9, V / c.e0)
+    plt.xlabel("z [nm]")
+    plt.ylabel("V [eV]")
+    plt.title("Potential")
+    plt.show()
+
+def H(H: sp.spmatrix):
+    plt.figure()
+    plt.title("Hamiltonian")
+    plt.imshow(np.real(H.toarray()))
+    plt.show()
+
+def psi(z: np.ndarray, E: np.ndarray, psi: np.ndarray):
+    plt.figure()
+    plt.suptitle("$|\Psi_{1,2}|^2$")
+    plt.subplot(2, 1, 1)
+    plt.plot(z, abs(psi[:, 0])**2)
+    plt.title(E[0] / c.e0)
+    plt.subplot(2, 1, 2)
+    plt.plot(z, abs(psi[:, 1])**2)
+    plt.title(E[1] / c.e0)
+    plt.tight_layout()
+    plt.show()

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -58,7 +58,7 @@ def psi2_animation(z: np.ndarray, V: np.ndarray, abs_psi_squared: np.ndarray):
     def init():
         ax1.set_title("$|\Psi|^2$")
         ax2.set_title("Potential [eV]")
-        ax1.set_ylim(0, 0.2)
+        # ax1.set_ylim(0, 0.2)
         ax2.set_ylim(-2, 10)
         fig.tight_layout()
         return ln_psi, ln_V,

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -42,7 +42,12 @@ def psi(z: np.ndarray, E: np.ndarray, psi: np.ndarray):
 def psi2_3D(z: np.ndarray, t: np.ndarray, abs_psi_squared: np.ndarray):
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
     X, Y = np.meshgrid(z / 1e-9, t / 1e-15)
-    surf = ax.plot_surface(X, Y, abs_psi_squared, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
+    surf = ax.plot_surface(
+        X, Y, abs_psi_squared, 
+        cmap=cm.get_cmap("viridis"),
+        linewidth=0, 
+        antialiased=False
+        )
     plt.xlabel("z [nm]")
     plt.ylabel("t [fs]")
     plt.title("$|\Psi|^2$")
@@ -52,19 +57,16 @@ def psi2_3D(z: np.ndarray, t: np.ndarray, abs_psi_squared: np.ndarray):
 def psi2_animation(z: np.ndarray, V: np.ndarray, abs_psi_squared: np.ndarray):
     fig, (ax1, ax2) = plt.subplots(2, 1)
 
-    # nicer x-axis
-    z /= 1e-9
-
-    ln_psi, = ax1.plot(z, abs_psi_squared[0, :])
-    ln_V, = ax2.plot(z, V[0, :])
+    ln_psi, = ax1.plot(z / 1e-9, abs_psi_squared[0, :])
+    ln_V, = ax2.plot(z / 1e-9, V[0, :] / c.e0)
 
     def init():
         ax1.set_title("$|\Psi|^2$")
         ax1.set_xlabel("z [nm]")
         ax2.set_title("Potential [eV]")
         ax2.set_xlabel("z [nm]")
-        # ax1.set_ylim(0, 0.2)
-        ax2.set_ylim(-2, 10)
+        ax1.set_ylim(0, np.max(abs_psi_squared) * 1.1)
+        ax2.set_ylim(np.min(V / c.e0), np.max(V / c.e0))
         fig.tight_layout()
         return ln_psi, ln_V,
 
@@ -73,8 +75,8 @@ def psi2_animation(z: np.ndarray, V: np.ndarray, abs_psi_squared: np.ndarray):
             yield abs_psi_squared[n, :], V[n, :]
 
     def update(data):
-        ln_psi.set_data(z, data[0])
-        ln_V.set_data(z, data[1] / c.e0)
+        ln_psi.set_data(z / 1e-9, data[0])
+        ln_V.set_data(z / 1e-9, data[1] / c.e0)
         return ln_psi, ln_V,
 
     ani = FuncAnimation(fig, update, frames=frames, init_func=init, blit=True)

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -39,20 +39,20 @@ def psi(z: np.ndarray, E: np.ndarray, psi: np.ndarray):
     plt.tight_layout()
     plt.show()
 
-def psi_3D(z: np.ndarray, t: np.ndarray, psi: np.ndarray):
+def psi2_3D(z: np.ndarray, t: np.ndarray, abs_psi_squared: np.ndarray):
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
     X, Y = np.meshgrid(z, t)
-    surf = ax.plot_surface(X, Y, abs(psi)**2, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
+    surf = ax.plot_surface(X, Y, abs_psi_squared, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
     plt.xlabel("z [m]")
     plt.ylabel("t [s]")
     plt.title("$|\Psi|^2$")
     fig.colorbar(surf, shrink=0.5, aspect=5)
     plt.show()
 
-def psi_animation(z: np.ndarray, V: np.ndarray, psi: np.ndarray):
+def psi2_animation(z: np.ndarray, V: np.ndarray, abs_psi_squared: np.ndarray):
     fig, (ax1, ax2) = plt.subplots(2, 1)
 
-    ln_psi, = ax1.plot(z, abs(psi[0, :])**2)
+    ln_psi, = ax1.plot(z, abs_psi_squared[0, :])
     ln_V, = ax2.plot(z, V[0, :])
 
     def init():
@@ -64,11 +64,11 @@ def psi_animation(z: np.ndarray, V: np.ndarray, psi: np.ndarray):
         return ln_psi, ln_V,
 
     def frames():
-        for n in range(psi.shape[0]):
-            yield psi[n, :], V[n, :]
+        for n in range(abs_psi_squared.shape[0]):
+            yield abs_psi_squared[n, :], V[n, :]
 
     def update(data):
-        ln_psi.set_data(z, abs(data[0])**2)
+        ln_psi.set_data(z, data[0])
         ln_V.set_data(z, data[1] / c.e0)
         return ln_psi, ln_V,
 

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -32,19 +32,19 @@ def psi(z: np.ndarray, E: np.ndarray, psi: np.ndarray):
     plt.suptitle("$|\Psi_{1,2}|^2$")
     plt.subplot(2, 1, 1)
     plt.plot(z, abs(psi[:, 0])**2)
-    plt.title(E[0] / c.e0)
+    plt.title(f"E$_1$: {E[0] / c.e0 :.3f} eV")
     plt.subplot(2, 1, 2)
     plt.plot(z, abs(psi[:, 1])**2)
-    plt.title(E[1] / c.e0)
+    plt.title(f"E$_2$: {E[1] / c.e0 :.3f} eV")
     plt.tight_layout()
     plt.show()
 
 def psi2_3D(z: np.ndarray, t: np.ndarray, abs_psi_squared: np.ndarray):
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
-    X, Y = np.meshgrid(z, t)
+    X, Y = np.meshgrid(z / 1e-9, t / 1e-15)
     surf = ax.plot_surface(X, Y, abs_psi_squared, cmap=cm.get_cmap("viridis"),linewidth=0, antialiased=False)
-    plt.xlabel("z [m]")
-    plt.ylabel("t [s]")
+    plt.xlabel("z [nm]")
+    plt.ylabel("t [fs]")
     plt.title("$|\Psi|^2$")
     fig.colorbar(surf, shrink=0.5, aspect=5)
     plt.show()
@@ -52,12 +52,17 @@ def psi2_3D(z: np.ndarray, t: np.ndarray, abs_psi_squared: np.ndarray):
 def psi2_animation(z: np.ndarray, V: np.ndarray, abs_psi_squared: np.ndarray):
     fig, (ax1, ax2) = plt.subplots(2, 1)
 
+    # nicer x-axis
+    z /= 1e-9
+
     ln_psi, = ax1.plot(z, abs_psi_squared[0, :])
     ln_V, = ax2.plot(z, V[0, :])
 
     def init():
         ax1.set_title("$|\Psi|^2$")
+        ax1.set_xlabel("z [nm]")
         ax2.set_title("Potential [eV]")
+        ax2.set_xlabel("z [nm]")
         # ax1.set_ylim(0, 0.2)
         ax2.set_ylim(-2, 10)
         fig.tight_layout()

--- a/year_4/TUM_quantum_sim/exam/plot.py
+++ b/year_4/TUM_quantum_sim/exam/plot.py
@@ -74,3 +74,10 @@ def psi2_animation(z: np.ndarray, V: np.ndarray, abs_psi_squared: np.ndarray):
 
     ani = FuncAnimation(fig, update, frames=frames, init_func=init, blit=True)
     plt.show()
+
+def psi2_z(t: np.ndarray, z_ind: int, abs_psi_squared: np.ndarray):
+    plt.figure()
+    plt.plot(t / 1e-15, abs_psi_squared[:, z_ind])
+    plt.xlabel("time [fs]")
+    plt.ylabel(f"$|\psi_{{{int(z_ind)}}}|^2$")
+    plt.show()

--- a/year_4/TUM_quantum_sim/exam/potential.py
+++ b/year_4/TUM_quantum_sim/exam/potential.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from TUM_quantum_sim import constants as c
+
+def static(
+    z: float | np.ndarray,
+    a: float,
+    Vb: float
+    ) -> np.ndarray:
+    """create a discretised array of the potential
+
+    Args:
+        z (float | np.ndarray): z coordinate in potential, [m]
+        a (float): Potential function parameter, [m]
+        Vb (float): Energy scaling, [J]
+
+    Returns:
+        float | np.ndarray: potential [J]
+    """
+    z0 = a / (4*2**0.5)
+    return Vb * (-0.25 * (z/z0)**2 + 1/64 * (z/z0)**4)
+
+def temporal(
+    z: float | np.ndarray,
+    t: float,
+    E: float,
+    omega: float
+    ) -> float | np.ndarray:
+    """Calculate the temporal evolution of the potential
+
+    Args:
+        z (float | np.ndarray): position [m]
+        t (float): time [s]
+        E (float): Electric field strength [V/m]
+        omega (float): frequency, [rad/s]
+
+    Returns:
+        float | np.ndarray: potential [J]
+    """
+    return -c.e0 * E * z * np.sin(omega * t)
+
+def total(
+    z: float | np.ndarray,
+    t: float,
+    a: float,
+    Vb: float,
+    E: float,
+    omega: float
+    ) -> float | np.ndarray:
+    """Calculate potential
+
+    Args:
+        z (float | np.ndarray): z coordinate in potential, [m]
+        t (float): time [s]
+        a (float): Potential function parameter, [m]
+        Vb (float): Energy scaling, [J]
+        E (float): Electric field strength [V/m]
+        omega (float): frequency, [rad/s]
+
+    Returns:
+        float | np.ndarray: potential [J]
+    """
+    return static(z, a, Vb) + temporal(z, t, E, omega)

--- a/year_4/TUM_quantum_sim/exam/sparse_override.py
+++ b/year_4/TUM_quantum_sim/exam/sparse_override.py
@@ -1,0 +1,16 @@
+"""
+
+Custom class to hopefully speed up hamiltonian addition
+
+"""
+from scipy import sparse as sp
+import numpy as np
+
+class Hamiltonian(sp.dia_matrix):
+
+    def __add__(self, other):
+        if isinstance(other, np.ndarray):
+            self.setdiag(self.diagonal(0) + other)
+            return self
+        else:
+            return super().__add__(other)

--- a/year_4/TUM_quantum_sim/exam/sparse_override.py
+++ b/year_4/TUM_quantum_sim/exam/sparse_override.py
@@ -10,11 +10,11 @@ import numpy as np
 class Hamiltonian(sp.dia_matrix):
 
     def add_static_potential(self, V0: np.ndarray):
-        self.__default_data = self.data
-        self.__default_data[1, :] += V0
+        self.data[1, :] += V0
+        self.__default_data = self.data.copy()
     
-    def add(self, potential) -> Hamiltonian:
-            self.data = self.__default_data
+    def add(self, potential: np.ndarray) -> Hamiltonian:
+            self.data = self.__default_data.copy()
             # index 1 is the central diagonal
             self.data[1, :] += potential
             return self

--- a/year_4/TUM_quantum_sim/exam/sparse_override.py
+++ b/year_4/TUM_quantum_sim/exam/sparse_override.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 
 Custom class to hopefully speed up hamiltonian addition
@@ -8,9 +9,12 @@ import numpy as np
 
 class Hamiltonian(sp.dia_matrix):
 
-    def __add__(self, other):
-        if isinstance(other, np.ndarray):
-            self.setdiag(self.diagonal(0) + other)
+    def add_static_potential(self, V0: np.ndarray):
+        self.__default_data = self.data
+        self.__default_data[1, :] += V0
+    
+    def add(self, potential) -> Hamiltonian:
+            self.data = self.__default_data
+            # index 1 is the central diagonal
+            self.data[1, :] += potential
             return self
-        else:
-            return super().__add__(other)


### PR DESCRIPTION
The takehome-exam-task was to do exercise 5 with the leapfrog scheme for time propagation instead of the current cranc-nicholson.

I did a lot of optimisations this time, mainly changing the sparse format, solving the linear system instead of inverting the matrix, and subclassing the sparse matrix to circumvent a lot of overhead. 
In total, around 30x speedup, 30 -> 0.5 seconds

Also changed the logging import in a couple of the exercises